### PR TITLE
fix: cohere.md pic link bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ static/.DS_Store
 static/images/.DS_Store
 .DS_Store
 .temp
+.idea
 node_modules
 package-lock.json
 yarn.lock

--- a/docs/gallery/lines_bars_and_markers/cohere.md
+++ b/docs/gallery/lines_bars_and_markers/cohere.md
@@ -2,7 +2,7 @@
 
 举例说明如何绘制两个信号的相干性。
 
-![绘制两个信号的相干性图示](https://matplotlib.org/_images/sphx_glr_categorical_variables_001.png)
+![绘制两个信号的相干性图示](https://matplotlib.org/_images/sphx_glr_cohere_thumb.png)
 
 ```python
 import numpy as np


### PR DESCRIPTION
<img width="1173" alt="Screen Shot 2022-11-09 at 17 10 50" src="https://user-images.githubusercontent.com/47740312/200789809-aee9c93d-5d9a-48e9-a2d4-c3c59879f4e2.png">
<img width="177" alt="Screen Shot 2022-11-09 at 17 10 58" src="https://user-images.githubusercontent.com/47740312/200789826-66f2765a-11d7-464f-9c31-55ddfbf41017.png">
<img width="1234" alt="Screen Shot 2022-11-09 at 17 11 09" src="https://user-images.githubusercontent.com/47740312/200789836-d46a1dfd-895d-4c11-b0b3-5fb81bf089f8.png">

Problem：
    When you click on the link above, the picture in cohere.md is wrong. In order to git ignore .idea, I added a .idea line to gitignore. Thank you.
